### PR TITLE
Make api return json instead of string

### DIFF
--- a/do.py
+++ b/do.py
@@ -13,7 +13,7 @@ class Stock(Resource):
         if name:
             try:
                 stock = Scrapy(stock=name)
-                return json.dumps(stock.getPrice()), 200
+                return stock.getPrice(), 200
             except:
                 return "Invalid Stock Ticker", 404
         return "Bad Request: Provide Stock Ticker", 400


### PR DESCRIPTION
`json.dumps` makes the API return a string when it should probably return a json object. In its current form it breaks the RapidApi test interface as that expects a json object to be returned.